### PR TITLE
Update Plugin Version

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -42,7 +42,7 @@ class Plugin extends Base
 
     public function getPluginVersion()
     {
-        return '1.3.3';
+        return '1.4.0';
     }
 
     public function getPluginHomepage()


### PR DESCRIPTION
Brings the plugin version number in line with the current github version number, removing an issue where kanboard is reporting there is a plugin update while using the latest version.